### PR TITLE
Fix typo in usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ function App() {
 
   // [800, 450] on the server, replaced by the values from window on the client
   const [width, height] = useSafeWindow(
-    window => [window.innerHeight, window.innerHeight],
+    window => [window.innerWidth, window.innerHeight],
     [800, 450]
   );
 


### PR DESCRIPTION
The first `window.innerHeight` should be `window.innerWidth`, or it'll provide the height as for the width.
Just accidentally found this typo when I copied the usage code! 🤣